### PR TITLE
Ese python bindings - API improvement

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -27,8 +27,8 @@ JET_MovePrevious = -1;
 JET_MoveNext = 1;
 JET_MoveLast = 2147483647;
  ```
- - `get_row(table_id, column_info) -> Option<PyObject>` - will return object or None, if field is NULL
- - `get_row_mv(table_id, column_info, multi_value_index) -> PyResult<Option<PyObject>>` - will return multi-value object at index (itagSequence) or None, if field is NULL
+ - `get_value(table_id, column_info) -> Option<PyObject>` - will return object or None, if field is NULL
+ - `get_value_mv(table_id, column_info, multi_value_index) -> PyResult<Option<PyObject>>` - will return multi-value object at index (itagSequence) or None, if field is NULL
 
 Python wrapper usage sample:
 ```
@@ -51,7 +51,7 @@ for t in tables:
 	while True:
 		print("|", end='')
 		for c in columns:
-			i = edb.get_row(tbl, c)
+			i = edb.get_value(tbl, c)
 			print(" {} |".format(i), end='')
 		print("")
 		if not edb.move_row(tbl, 1):

--- a/python/py/list.py
+++ b/python/py/list.py
@@ -18,7 +18,7 @@ for t in tables:
 	while True:
 		print("|", end='')
 		for c in columns:
-			i = edb.get_row(tbl, c)
+			i = edb.get_value(tbl, c)
 			if c.typ == 8: # datetime
 				i = datetime.utcfromtimestamp(i)
 			print(" {} |".format(i), end='')

--- a/python/py/test.py
+++ b/python/py/test.py
@@ -24,26 +24,26 @@ class TestEseDbMethods(unittest.TestCase):
 
 		self.assertEqual(len(edb.get_columns(t)), 18)
 
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "Bit")), 0)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "UnsignedByte")), 255)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "Short")), None)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "Long")), -2147483648)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "Currency")), 350050)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "IEEESingle")), 3.141592025756836)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "IEEEDouble")), 3.141592653589)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "UnsignedLong")), 4294967295)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "LongLong")), 9223372036854775807)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "UnsignedShort")), 65535)
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "DateTime")), datetime(2021, 3, 29, 11, 49, 47))
-		self.assertEqual(edb.get_row(tbl, edb.get_column(t, "GUID")), "{4D36E96E-E325-11CE-BFC1-08002BE10318}")
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "Bit")), 0)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "UnsignedByte")), 255)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "Short")), None)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "Long")), -2147483648)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "Currency")), 350050)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "IEEESingle")), 3.141592025756836)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "IEEEDouble")), 3.141592653589)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "UnsignedLong")), 4294967295)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "LongLong")), 9223372036854775807)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "UnsignedShort")), 65535)
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "DateTime")), datetime(2021, 3, 29, 11, 49, 47))
+		self.assertEqual(edb.get_value(tbl, edb.get_column(t, "GUID")), "{4D36E96E-E325-11CE-BFC1-08002BE10318}")
 
-		b = edb.get_row(tbl, edb.get_column(t, "Binary"))
+		b = edb.get_value(tbl, edb.get_column(t, "Binary"))
 		ind = 0
 		for i in b:
 			self.assertEqual(i, ind % 255)
 			ind += 1
 
-		b = edb.get_row(tbl, edb.get_column(t, "LongBinary"))
+		b = edb.get_value(tbl, edb.get_column(t, "LongBinary"))
 		ind = 0
 		for i in b:
 			self.assertEqual(i, ind % 255)
@@ -51,13 +51,13 @@ class TestEseDbMethods(unittest.TestCase):
 
 		abc = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
 
-		b = edb.get_row(tbl, edb.get_column(t, "Text"))
+		b = edb.get_value(tbl, edb.get_column(t, "Text"))
 		ind = 0
 		for i in b:
 			self.assertEqual(i, abc[ind % len(abc)])
 			ind += 1
 
-		b = edb.get_row_mv(tbl, edb.get_column(t, "Text"), 2)
+		b = edb.get_value_mv(tbl, edb.get_column(t, "Text"), 2)
 		h = "Hello"
 		ind = 0
 		for i in range(0,len(b)-2):
@@ -65,7 +65,7 @@ class TestEseDbMethods(unittest.TestCase):
 			ind += 1
 
 		if system() == 'Windows':
-			b = edb.get_row(tbl, edb.get_column(t, "LongText"))
+			b = edb.get_value(tbl, edb.get_column(t, "LongText"))
 			ind = 0
 			for i in b:
 				self.assertEqual(i, abc[ind % len(abc)])
@@ -77,24 +77,24 @@ class TestEseDbMethods(unittest.TestCase):
 		edb = ese_parser.PyEseDb("../lib/testdata/Current.mdb")
 		t = "CLIENTS"
 		tbl = edb.open_table(t)
-		d1 = edb.get_row(tbl, edb.get_column(t, "InsertDate"))
+		d1 = edb.get_value(tbl, edb.get_column(t, "InsertDate"))
 		self.assertEqual(d1, datetime(2021, 6, 12, 23, 47, 21, 232324))
 		edb.move_row(tbl, 1)
-		d2 = edb.get_row(tbl, edb.get_column(t, "InsertDate"))
+		d2 = edb.get_value(tbl, edb.get_column(t, "InsertDate"))
 		self.assertEqual(d2, datetime(2021, 6, 12, 23, 48, 45, 468902))
 		edb.move_row(tbl, 1)
-		d3 = edb.get_row(tbl, edb.get_column(t, "InsertDate"))
+		d3 = edb.get_value(tbl, edb.get_column(t, "InsertDate"))
 		self.assertEqual(d3, datetime(2021, 6, 12, 23, 49, 44, 255548))
 		edb.move_row(tbl, 2147483647)  # move to the last row
-		d_last = edb.get_row(tbl, edb.get_column(t, "InsertDate"))
+		d_last = edb.get_value(tbl, edb.get_column(t, "InsertDate"))
 		self.assertEqual(d_last, datetime(2021, 6, 20, 20, 48, 48, 366867))
 
 		# Move to the first row again
 		edb.move_row(tbl, -2147483648)
-		total_access = edb.get_row(tbl, edb.get_column(t, "TotalAccesses"))  # for this column type get_row fetches data fine
+		total_access = edb.get_value(tbl, edb.get_column(t, "TotalAccesses"))  # for this column type get_value fetches data fine
 		self.assertEqual(total_access, 310)
 		edb.move_row(tbl, 1)  # move to the second row
-		total_access = edb.get_row(tbl, edb.get_column(t, "TotalAccesses"))
+		total_access = edb.get_value(tbl, edb.get_column(t, "TotalAccesses"))
 		self.assertEqual(total_access, 101)
 
 if __name__ == '__main__':

--- a/python/py/test.py
+++ b/python/py/test.py
@@ -14,6 +14,7 @@ class TestEseDbMethods(unittest.TestCase):
 		f = open("../lib/testdata/test.edb", "rb")
 		edb = ese_parser.PyEseDb(f)
 		self._test_db(edb)
+		f.close()
 
 	def _test_db(self, edb):
 		tables = edb.get_tables()
@@ -96,6 +97,8 @@ class TestEseDbMethods(unittest.TestCase):
 		edb.move_row(tbl, 1)  # move to the second row
 		total_access = edb.get_value(tbl, edb.get_column(t, "TotalAccesses"))
 		self.assertEqual(total_access, 101)
+
+		edb.close_table(tbl)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -303,6 +303,21 @@ impl PyEseDb {
             }
         }
     }
+
+    // ASDF-5542: new name for same API
+    fn get_value(&self, table: u64, column: &PyColumnInfo) -> PyResult<Option<PyObject>> {
+        self.get_row(table, column)
+    }
+
+    // ASDF-5542: new name for same API
+    fn get_value_mv(
+        &self,
+        table: u64,
+        column: &PyColumnInfo,
+        multi_value_index: u32,
+    ) -> PyResult<Option<PyObject>> {
+        self.get_row_mv(table, column, multi_value_index)
+    }
 }
 
 #[pymodule]


### PR DESCRIPTION
The `get_row(...)` function doesn't actually get a row; it takes a column name and returns a field.

Let's deprecate the existing function (leave it in so we don't break anything) and add a new one that's preferred: `get_field`, `get_column`, `get_value` - just something other than `get_row`.